### PR TITLE
Group sizes

### DIFF
--- a/GatheringAPI/Controllers/GroupController.cs
+++ b/GatheringAPI/Controllers/GroupController.cs
@@ -131,13 +131,21 @@ namespace GatheringAPI.Controllers
         public async Task<ActionResult> AddUser(long groupId, string userName)
         {
             GroupUser currentUser = await guRepo.GetGroupUser(groupId, UserId);
+            GroupDto currentGroup = await GetGroup(groupId);
 
             if (currentUser.Role == Role.owner || currentUser.Role == Role.admin)
             {
-                await repository.AddUserAsync(groupId, userName);
+                if(currentGroup.GroupUsers.Count < currentGroup.MaxUsers)
+                {
+                    await repository.AddUserAsync(groupId, userName);
 
-                long userId = await repository.FindUserIdByUserName(userName);
-                return CreatedAtAction(nameof(AddUser), new { groupId, userName }, null);
+                    long userId = await repository.FindUserIdByUserName(userName);
+                    return CreatedAtAction(nameof(AddUser), new { groupId, userName }, null);
+                }
+                else
+                {
+                    return BadRequest("Cannot add users to this group. This group is currently full. Please upgrade to add more users.");
+                }
             }
             else
             {

--- a/GatheringAPI/Controllers/GroupController.cs
+++ b/GatheringAPI/Controllers/GroupController.cs
@@ -135,7 +135,8 @@ namespace GatheringAPI.Controllers
 
             if (currentUser.Role == Role.owner || currentUser.Role == Role.admin)
             {
-                if(currentGroup.GroupUsers.Count < currentGroup.MaxUsers)
+                Console.WriteLine($"{currentGroup.GroupUsers.Count}, {currentGroup.MaxUsers}");
+                if(currentGroup.GroupUsers.Count < currentGroup.MaxUsers || currentGroup.MaxUsers == -1)
                 {
                     await repository.AddUserAsync(groupId, userName);
 
@@ -158,13 +159,20 @@ namespace GatheringAPI.Controllers
         public async Task<ActionResult<Event>> AddEventToGroup(Event @event, long groupId)
         {
             GroupUser currentUser = await guRepo.GetGroupUser(groupId, UserId);
+            GroupDto currentGroup = await GetGroup(groupId);
             
             if(currentUser.Role != Role.user)
             {
-                await repository.CreateEventAsync(@event, UserId, groupId);
-                return Ok();
+                if(currentGroup.GroupEvents.Count < currentGroup.MaxEvents || currentGroup.MaxEvents == -1)
+                {
+                    await repository.CreateEventAsync(@event, UserId, groupId);
+                    return Ok();
+                }
+                else
+                {
+                    return BadRequest("Your group has reached the maximum number of created events for the month. Please upgrade to create more.");
+                }
             }
-
             return Unauthorized("Only certain users in your group can create events. Please talk to the group admins if you think that should be you.");
         }
         

--- a/GatheringAPI/Migrations/20210310031404_AddGroupSizes.Designer.cs
+++ b/GatheringAPI/Migrations/20210310031404_AddGroupSizes.Designer.cs
@@ -4,14 +4,16 @@ using GatheringAPI.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GatheringAPI.Migrations
 {
     [DbContext(typeof(GatheringDbContext))]
-    partial class GatheringDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210310031404_AddGroupSizes")]
+    partial class AddGroupSizes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GatheringAPI/Migrations/20210310031404_AddGroupSizes.cs
+++ b/GatheringAPI/Migrations/20210310031404_AddGroupSizes.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GatheringAPI.Migrations
+{
+    public partial class AddGroupSizes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "GroupSize",
+                table: "Groups",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<long>(
+                name: "MaxEvents",
+                table: "Groups",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.AddColumn<long>(
+                name: "MaxUsers",
+                table: "Groups",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GroupSize",
+                table: "Groups");
+
+            migrationBuilder.DropColumn(
+                name: "MaxEvents",
+                table: "Groups");
+
+            migrationBuilder.DropColumn(
+                name: "MaxUsers",
+                table: "Groups");
+        }
+    }
+}

--- a/GatheringAPI/Models/Api/GroupDto.cs
+++ b/GatheringAPI/Models/Api/GroupDto.cs
@@ -19,6 +19,8 @@ namespace GatheringAPI.Models.Api
         public List<GroupUserDto> GroupUsers { get; set; }
 
         public List<JoinRequestDto> RequestsToJoin { get; set; }
+
+        public long MaxUsers { get; set; }
     }
 
     public class GroupEventDto

--- a/GatheringAPI/Models/Api/GroupDto.cs
+++ b/GatheringAPI/Models/Api/GroupDto.cs
@@ -21,6 +21,8 @@ namespace GatheringAPI.Models.Api
         public List<JoinRequestDto> RequestsToJoin { get; set; }
 
         public long MaxUsers { get; set; }
+
+        public long MaxEvents { get; set; }
     }
 
     public class GroupEventDto

--- a/GatheringAPI/Models/Group.cs
+++ b/GatheringAPI/Models/Group.cs
@@ -21,5 +21,21 @@ namespace GatheringAPI.Models
         public bool IsPublic { get; set; } = false;
 
         public List<JoinRequest> RequestsToJoin { get; set; }
+
+        public GroupSizes GroupSize { get; set; }
+
+        public long MaxUsers { get; set; }
+
+        public long MaxEvents { get; set; }
+    }
+
+    public enum GroupSizes
+    {
+        free = 20,
+        extraSmall = 50,
+        small = 100,
+        medium = 250,
+        large = 1000,
+        infinite = 1001
     }
 }

--- a/GatheringAPI/Models/Group.cs
+++ b/GatheringAPI/Models/Group.cs
@@ -22,6 +22,7 @@ namespace GatheringAPI.Models
 
         public List<JoinRequest> RequestsToJoin { get; set; }
 
+        [Required]
         public GroupSizes GroupSize { get; set; }
 
         public long MaxUsers { get; set; }

--- a/GatheringAPI/Services/DbGroupRepo.cs
+++ b/GatheringAPI/Services/DbGroupRepo.cs
@@ -430,14 +430,31 @@ namespace GatheringAPI.Services
 
         public async Task RequestToJoinGroupById(long groupId, long userId)
         {
-            JoinRequest joinRequest = new JoinRequest
-            {
-                GroupId = groupId,
-                UserId = userId
-            };
+            Group currentGroup = await GetGroup(groupId);
 
-            _context.JoinRequests.Add(joinRequest);
-            await _context.SaveChangesAsync();
+            if(currentGroup.IsPublic == false)
+            {
+                JoinRequest joinRequest = new JoinRequest
+                {
+                    GroupId = groupId,
+                    UserId = userId
+                };
+
+                _context.JoinRequests.Add(joinRequest);
+                await _context.SaveChangesAsync();
+            }
+            else
+            {
+                var groupUser = new GroupUser
+                {
+                    GroupId = groupId,
+                    UserId = userId,
+                    Role = Role.user
+                };
+
+                _context.GroupUsers.Add(groupUser);
+                await _context.SaveChangesAsync();
+            }
         }
 
         public async Task RespondToGroupJoinRequest(long groupId, long userId, JoinStatus status)

--- a/GatheringAPI/Services/DbGroupRepo.cs
+++ b/GatheringAPI/Services/DbGroupRepo.cs
@@ -32,6 +32,40 @@ namespace GatheringAPI.Services
         {
             group.GroupUsers = new List<GroupUser>();
             group.GroupUsers.Add(new GroupUser { UserId = userId, Role = Role.owner });
+            group.IsPublic = false;
+
+            switch (group.GroupSize)
+            {
+                case GroupSizes.free:
+                    group.MaxUsers = 20;
+                    group.MaxEvents = 300;
+                    group.IsPublic = true;
+                    break;
+                case GroupSizes.extraSmall:
+                    group.MaxUsers = 50;
+                    group.MaxEvents = 750;
+                    break;
+                case GroupSizes.small:
+                    group.MaxUsers = 100;
+                    group.MaxEvents = 1500;
+                    break;
+                case GroupSizes.medium:
+                    group.MaxUsers = 250;
+                    group.MaxEvents = 3750;
+                    break;
+                case GroupSizes.large:
+                    group.MaxUsers = 1000;
+                    group.MaxEvents = 15000;
+                    break;
+                case GroupSizes.infinite:
+                    group.MaxUsers = -1;
+                    group.MaxEvents = -1;
+                    break;
+                default:
+                    Console.WriteLine("Should not get here.");
+                    break;
+            }
+
             _context.Groups.Add(@group);
             await _context.SaveChangesAsync();
         }

--- a/GatheringAPI/Services/DbGroupRepo.cs
+++ b/GatheringAPI/Services/DbGroupRepo.cs
@@ -119,9 +119,9 @@ namespace GatheringAPI.Services
                         .Select(gu => new GroupUserDto
                         {
                             UserId = gu.UserId,
-                            User = gu.User,
+                            User = null,
                             GroupId = gu.GroupId,
-                            Group = gu.Group,
+                            Group = null,
                             Role = gu.Role,
                             RoleString = gu.Role.ToString()
                         })
@@ -135,7 +135,9 @@ namespace GatheringAPI.Services
                             Status = jr.Status,
                             UserId = jr.UserId
                         })
-                        .ToList()
+                        .ToList(),
+                    MaxUsers = group.MaxUsers,
+                    MaxEvents = group.MaxEvents
                 })
                 .FirstOrDefault();
         }

--- a/GatheringAPI/Services/DbGroupRepo.cs
+++ b/GatheringAPI/Services/DbGroupRepo.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using GatheringAPI.Data;
 using GatheringAPI.Models;
 using GatheringAPI.Models.Api;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Twilio;

--- a/GatheringAPI/Services/DbGroupUserRepo.cs
+++ b/GatheringAPI/Services/DbGroupUserRepo.cs
@@ -1,8 +1,5 @@
 ﻿using GatheringAPI.Data;
 using GatheringAPI.Models;
-using Microsoft.Extensions.Configuration;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;

--- a/GatheringAPI/Services/DbUserRepo.cs
+++ b/GatheringAPI/Services/DbUserRepo.cs
@@ -33,7 +33,7 @@ namespace GatheringAPI.Services
                 {
                     Id = user.Id,
                     Username = user.UserName,
-                    Token = await tokenService.GetToken(user, TimeSpan.FromHours(12)),
+                    Token = await tokenService.GetToken(user, TimeSpan.FromDays(30)),
                 };
             }
             return null;


### PR DESCRIPTION
Effort to add logic that sets group sizes for future use that would be behind a paywall. The larger the group, the more it would charge each month to run it. This would affect how many users can be in a group and how many events that group is allowed to create each month. 